### PR TITLE
BECOME_METHODS is deprecated

### DIFF
--- a/ansible-plugins/ssh_citrix_adc.py
+++ b/ansible-plugins/ssh_citrix_adc.py
@@ -291,6 +291,7 @@ from ansible.module_utils.parsing.convert_bool import BOOLEANS, boolean
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.plugins.connection.ssh import Connection as ConnectionSsh
+from ansible.plugins.loader import become_loader
 
 try:
     from __main__ import display
@@ -389,7 +390,7 @@ class Connection(ConnectionSsh):
 
     transport = 'ssh_citrix_adc'
     has_pipelining = True
-    become_methods = frozenset(C.BECOME_METHODS).difference(['runas'])
+    become_methods = frozenset([method.name for method in become_loader.all()]).difference(['runas'])
     name = 'ssh_citrix_adc'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This switches over to the become_loader method in advance of
Ansible 2.10.

Fixes
```
[DEPRECATION WARNING]: ansible.constants.BECOME_METHODS is deprecated, please use ansible.plugins.loader.become_loader. This list is statically defined and may not include all become methods. This feature will be removed in version
2.10. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```