### PR TITLE
Add support for SNI SSL Certificates in citrix_adc_lb_vserver

### DIFF
--- a/ansible-modules/citrix_adc_lb_vserver.py
+++ b/ansible-modules/citrix_adc_lb_vserver.py
@@ -993,7 +993,7 @@ diff:
     sample: { 'clttimeout': 'difference. ours: (float) 10.0 other: (float) 20.0' }
 '''
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.netscaler.netscaler import (
+from ansible.module_utils.network.citrix_adc.citrix_adc import (
     ConfigProxy,
     get_nitro_client,
     netscaler_common_arguments,

--- a/ansible-modules/citrix_adc_lb_vserver.py
+++ b/ansible-modules/citrix_adc_lb_vserver.py
@@ -1401,13 +1401,13 @@ def ssl_certkey_bindings_sync(client, module):
         bindings = sslvserver_sslcertkey_binding.get(client, vservername)
     log('bindings len is %s' % len(bindings))
 
-    # # Delete existing bindings
+    # Delete existing bindings
     for binding in bindings:
         if not binding.snicert:
             log('ssl_certkey_bindings_sync delete certificate %s' % binding.certkeyname)
             sslvserver_sslcertkey_binding.delete(client, binding)
 
-    # # Add binding if appropriate
+    # Add binding if appropriate
     if module.params['ssl_certkey'] is not None:
         binding = sslvserver_sslcertkey_binding()
         binding.vservername = module.params['name']


### PR DESCRIPTION
Add support for the SNI type certificates.
Current module throws an error when this type of certificates are attached to the server. 

This feature will take a list of certificates and bind them to virtual. 
The ssl_certkey is still a string variable and is responsible for the main virtual certificate.

Support for the SNI certificates (SNIENables setting on the server) still needs to be added separately outside this module. Maybe in the future also should cover this part.

Also, this change is fixing a bug when we configure ssl vserver,  ansible is run in check mode and the virtual is not created yet. With current code, we get an error.
