### PR TITLE
Add support for the SNI SSL Certificates in citrix_adc_cs_vserver 

### DIFF
--- a/ansible-modules/citrix_adc_cs_vserver.py
+++ b/ansible-modules/citrix_adc_cs_vserver.py
@@ -475,6 +475,13 @@ options:
             - This option is only applicable only when C(servicetype) is C(SSL).
         version_added: "2.5"
 
+    ssl_sni_certkeys:
+        type: list
+        description:
+            - SSL SNI certificates that will be bind to the vserver
+            - The ssl certificates must already exist.
+            - This option is only applicable only when C(servicetype) is C(SSL).
+
     disabled:
         description:
             - When set to C(yes) the cs vserver will be disabled.
@@ -642,7 +649,8 @@ from ansible.module_utils.network.citrix_adc.citrix_adc import (
     log,
     loglines,
     ensure_feature_is_enabled,
-    get_immutables_intersection
+    get_immutables_intersection,
+    NitroAPIFetcher
 )
 try:
     from nssrc.com.citrix.netscaler.nitro.resource.config.cs.csvserver import csvserver
@@ -949,21 +957,30 @@ def appfw_policybindings_identical(client, module):
 def ssl_certkey_bindings_identical(client, module):
     log('Checking if ssl cert key bindings are identical')
     vservername = module.params['name']
+
+    # return changed if cs vserver does not exist and the check_mode is used
+    if not cs_vserver_exists(client, module) and module.check_mode:
+        return False
+
     if sslvserver_sslcertkey_binding.count(client, vservername) == 0:
         bindings = []
     else:
         bindings = sslvserver_sslcertkey_binding.get(client, vservername)
 
+    certificate_list = [item.certkeyname for item in bindings if not item.snicert]
+    log('certificate_list without snicerts %s' % certificate_list)
+
     if module.params['ssl_certkey'] is None:
-        if len(bindings) == 0:
+        if len(certificate_list) == 0:
             return True
         else:
+            log('ssl_certkey differ: existing certificate: %s will be removed' % certificate_list)
             return False
     else:
-        certificate_list = [item.certkeyname for item in bindings]
         if certificate_list == [module.params['ssl_certkey']]:
             return True
         else:
+            log('ssl_certkey differ: existing certs: %s, new certs %s' % (certificate_list, module.params['ssl_certkey']))
             return False
 
 
@@ -977,8 +994,9 @@ def ssl_certkey_bindings_sync(client, module):
 
     # Delete existing bindings
     for binding in bindings:
-        log('Deleting existing binding for certkey %s' % binding.certkeyname)
-        sslvserver_sslcertkey_binding.delete(client, binding)
+        if not binding.snicert:
+            log('Deleting existing binding for certkey %s' % binding.certkeyname)
+            sslvserver_sslcertkey_binding.delete(client, binding)
 
     # Add binding if appropriate
     if module.params['ssl_certkey'] is not None:
@@ -987,6 +1005,88 @@ def ssl_certkey_bindings_sync(client, module):
         binding.vservername = module.params['name']
         binding.certkeyname = module.params['ssl_certkey']
         sslvserver_sslcertkey_binding.add(client, binding)
+
+def ssl_sni_certkeys_bindings_identical(client, module):
+    log('Entering ssl_sni_certkeys_bindings_identical')
+    vservername = module.params['name']
+
+    # return changed if vserver does not exist and the check_mode is used
+    if not cs_vserver_exists(client, module) and module.check_mode:
+        return False
+
+    if sslvserver_sslcertkey_binding.count(client, vservername) == 0:
+        bindings = []
+    else:
+        bindings = sslvserver_sslcertkey_binding.get(client, vservername)
+
+
+    certificate_list = [
+        item.certkeyname for item in bindings if item.snicert]
+    log('certificate_list with snicerts %s' % certificate_list)
+
+    if module.params['ssl_sni_certkeys'] is None:
+        if len(certificate_list) == 0:
+            return True
+        else:
+            log('ssl_sni_certkey differ: existing certificates: %s will be removed' %
+                certificate_list)
+            return False
+    else:
+        ssl_sni_certkeys = module.params['ssl_sni_certkeys'].copy()
+        ssl_sni_certkeys.sort()
+        certificate_list.sort()
+        if certificate_list == ssl_sni_certkeys:
+            return True
+        else:
+            log('ssl_certkey differ: existing certs: %s, new cert %s' %
+                (certificate_list, ssl_sni_certkeys))
+            return False
+
+def ssl_sni_certkeys_bindings_sync(client, module):
+    log('Syncing SNI ssl certificates')
+    vservername = module.params['name']
+
+    ssl_sni_certkeys = []
+
+    if module.params['ssl_sni_certkeys'] is not None:
+        if module.params['ssl_sni_certkeys'][0]:
+            ssl_sni_certkeys = module.params['ssl_sni_certkeys']
+        else:
+            ssl_sni_certkeys = []
+
+    if sslvserver_sslcertkey_binding.count(client, vservername) == 0:
+        bindings = []
+    else:
+        bindings = sslvserver_sslcertkey_binding.get(client, vservername)
+
+    configured_sni_certkeys = [
+        item.certkeyname for item in bindings if item.snicert]
+
+    log('ssl_sni_certkeys_bindings_sync sni certs count %s' % len(configured_sni_certkeys))
+
+    # Delete unwanted SNI bindings
+    for certkey in configured_sni_certkeys:
+        if certkey not in ssl_sni_certkeys:
+            log('ssl_certkey_bindings_sync delete SNI certificate %s' % certkey)
+            fetcher = NitroAPIFetcher(module)
+            del_args = {'certkeyname': certkey,
+                        'snicert': 'true'}
+            result = fetcher.delete(
+                'sslvserver_sslcertkey_binding', id=vservername, args=del_args)
+            if result['nitro_errorcode'] != 0:
+                log("ERROR ssl_certkey_bindings_sync nitro_errorcode %s nitro_message: %s" % (
+                    result['nitro_errorcode'], result.get('nitro_message')))
+
+    # Add missing SNI bindings
+    for sni_certkey in ssl_sni_certkeys:
+        if sni_certkey not in configured_sni_certkeys:
+            log('ssl_certkey_bindings_sync add new SNI certificate %s' %
+                    sni_certkey)
+            binding = sslvserver_sslcertkey_binding()
+            binding.vservername = module.params['name']
+            binding.certkeyname = sni_certkey
+            binding.snicert = True
+            sslvserver_sslcertkey_binding.add(client, binding)
 
 
 def diff_list(client, module, csvserver_proxy):
@@ -1206,6 +1306,7 @@ def main():
             default=False
         ),
         lbvserver=dict(type='str'),
+        ssl_sni_certkeys=dict(type='list'),
     )
 
     argument_spec = dict()
@@ -1434,6 +1535,12 @@ def main():
 
                     module_result['changed'] = True
 
+                if not ssl_sni_certkeys_bindings_identical(client, module):
+                    if not module.check_mode:
+                        ssl_sni_certkeys_bindings_sync(client, module)
+
+                    module_result['changed'] = True
+
             # Check default lb vserver
             if not default_lb_vserver_identical(client, module):
                 if not module.check_mode:
@@ -1459,6 +1566,9 @@ def main():
                 if module.params['servicetype'] == 'SSL':
                     if not ssl_certkey_bindings_identical(client, module):
                         module.fail_json(msg='sll certkey bindings not identical', **module_result)
+
+                    if not ssl_sni_certkeys_bindings_identical(client, module):
+                        module.fail_json(msg='ssl sni certkeys bindings not identical', **module_result)
 
         elif module.params['state'] == 'absent':
             log('Applying actions for state absent')


### PR DESCRIPTION
Add support for the SNI type certificates.
Current module throws an error when this type of certificates are attached to the server.

This feature will take a list of certificates and bind them to virtual.
The ssl_certkey is still a string variable and is responsible for the main virtual certificate.

Support for the SNI certificates (SNIENables setting on the server) still needs to be added separately outside this module. Maybe in the future also should cover this part.

Also, this change is fixing a bug when we configure ssl vserver, ansible is run in check mode and the virtual is not created yet. With current code, we get an error.

Similar to other PR for vserver: https://github.com/citrix/citrix-adc-ansible-modules/pull/115


Also I'm aware of other PR 
https://github.com/citrix/citrix-adc-ansible-modules/pull/113

But it's not backward compatibile and doesn't handle cert removal
It's described in other PR problem with python sdk as a workaround I used direct rest calls. 