### PR TITLE
Ignore default-path-monitor in service monitors comparison

### DIFF
--- a/ansible-modules/citrix_adc_service.py
+++ b/ansible-modules/citrix_adc_service.py
@@ -453,7 +453,7 @@ def get_actual_monitor_bindings(client, module):
     # Fallthrough to rest of execution
     for binding in service_lbmonitor_binding.get(client, module.params['name']):
         # Excluding default monitors since we cannot operate on them
-        if binding.monitor_name in ('tcp-default', 'ping-default'):
+        if binding.monitor_name in ('tcp-default', 'ping-default', 'default-path-monitor'):
             continue
         key = binding.monitor_name
         actual = lbmonitor_service_binding()


### PR DESCRIPTION
On netscaler cluster when a service has path monitoring enabled,
default-path-monitor is automatically bound to the service.
This change adds path monitor to the list of internal monitors
to ignore.