### PR TITLE
Correct install script for Ansible 2.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ lbvserver\_spilloverpolicy\_binding, lbvserver\_pqpolicy\_binding, lbgroup\_lbvs
 ## Installation
 
 ### Using `virtualenv` (recommended)
-Use of a python virtualenv during installation is recommended.
+Use of a python [virtualenv](https://docs.python-guide.org/dev/virtualenvs/) during installation is recommended.
 
-* Activate the virtualenv (`source bin/activate`)
+* Create the virtualenv (`virtualenv venv`)
+* Activate the virtualenv (`source venv/bin/activate`)
 * Install all dependencies by running ```pip install -r requirements.test.txt``` from the project checkout.
 * Install the citrix ADC modules using ```python install.py```
 

--- a/install.py
+++ b/install.py
@@ -67,7 +67,7 @@ def main():
     print('Ansible path is %s' % ansible_path)
 
     # Check to see if appropriate directories exist
-    if (major, minor) == (2, 4):
+    if (major, minor) == (2, 4) or major >= 3 or major == 2 and minor >= 8:
         module_utils_path = os.path.join(ansible_path, 'module_utils')
     else:
         module_utils_path = os.path.join(ansible_path, 'module_utils', 'network', 'netscaler')
@@ -81,6 +81,8 @@ def main():
     # Set modules path according to ansible version
     if major < 2 or major == 2 and minor <= 2:
         extra_modules_path = os.path.join(ansible_path, 'modules', 'extras', 'network')
+    elif major >= 3 or major == 2 and minor >= 8:
+        extra_modules_path = os.path.join(ansible_path, 'modules')
     else:
         extra_modules_path = os.path.join(ansible_path, 'modules', 'network')
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,3 @@
 paramiko
-file:../netscaler-ansible-modules/deps/nitro-python-1.0_kamet.tar.gz
+file:./deps/nitro-python-1.0_kamet.tar.gz
 git+https://github.com/ansible/ansible.git


### PR DESCRIPTION
This PR corrects the install script for Ansible versions 2.8+, as the Netscaler module was removed in 2.8 ([release notes](https://github.com/ansible/ansible/blob/4e8b240b8b74db2453851f12ec82c7f782289187/docs/docsite/rst/porting_guides/porting_guide_2.8.rst)).

The PR also clarifies the doc for installing using virtualenv and corrects a reference to the old repo name.

Resolves https://github.com/citrix/citrix-adc-ansible-modules/issues/117.