### PR TITLE
Fix lb_vserver module ssl certkey bindings lookup

### DIFF
--- a/ansible-collections/adc/plugins/modules/citrix_adc_lb_vserver.py
+++ b/ansible-collections/adc/plugins/modules/citrix_adc_lb_vserver.py
@@ -2131,7 +2131,7 @@ class ModuleExecutor(object):
         bound_lbvserver = None
         result = self.fetcher.get('sslvserver_sslcertkey_binding', self.module.params['name'])
 
-        if result['nitro_errorcode'] in [461, 1544]:
+        if result['nitro_errorcode'] in [258, 461, 1544]:
             bound_sslcertkeys = []
         elif result['nitro_errorcode'] != 0:
             raise NitroException(


### PR DESCRIPTION
When searching for a sslvserver_sslcertkey_binding
the expected error codes did not contain the one
returned by a cluster ADC deployment.

The fix is to include this error code as expected
so that execution continues normally.