### PR TITLE
fix(sslcertificatechain): POST to trigger auto-linking when chain is incomplete

### DIFF
--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -578,13 +578,55 @@ class ModuleExecutor(object):
             # non-updatable resources
             is_identical, immutable_keys_list = self.is_resource_identical()
             if is_identical:
-                log(
-                    "INFO: Resource `%s:%s` exists and is identical. No change required."
-                    % (
-                        self.resource_name,
-                        self.resource_id,
+                # For sslcertificatechain, the GET returns chain status but the
+                # POST triggers auto-linking. If the chain is incomplete, we must
+                # still POST to link it, even though the resource "exists".
+                if (
+                    self.resource_name == "sslcertificatechain"
+                    and self.existing_resource.get("chaincomplete") == "0"
+                ):
+                    log(
+                        "INFO: Resource `%s:%s` chain is incomplete (chaincomplete=0). Will POST to trigger auto-linking."
+                        % (
+                            self.resource_name,
+                            self.resource_id,
+                        )
                     )
-                )
+                    self.module_result["changed"] = True
+                    # Build diff showing the chain linking that will occur
+                    possible_links = self.existing_resource.get(
+                        "chainpossiblelinks", []
+                    )
+                    current_links = self.existing_resource.get("chainlinked", [])
+                    self.update_diff_list(
+                        existing={
+                            "certkeyname": self.resource_id,
+                            "chaincomplete": "0",
+                            "chainlinked": current_links,
+                            "chainpossiblelinks": possible_links,
+                        },
+                        desired={
+                            "certkeyname": self.resource_id,
+                            "chaincomplete": "1",
+                            "chainlinked": current_links + possible_links,
+                            "chainpossiblelinks": [],
+                        },
+                    )
+                    ok, err = create_resource(
+                        self.client,
+                        self.resource_name,
+                        self.resource_module_params,
+                    )
+                    if not ok:
+                        self.return_failure(err)
+                else:
+                    log(
+                        "INFO: Resource `%s:%s` exists and is identical. No change required."
+                        % (
+                            self.resource_name,
+                            self.resource_id,
+                        )
+                    )
             else:
                 self.module_result["changed"] = True
                 if self.resource_name == "systemfile":

--- a/tests/integration/targets/sslcertificatechain/aliases
+++ b/tests/integration/targets/sslcertificatechain/aliases
@@ -1,0 +1,2 @@
+unstable
+netscaler/adc

--- a/tests/integration/targets/sslcertificatechain/tasks/main.yaml
+++ b/tests/integration/targets/sslcertificatechain/tasks/main.yaml
@@ -1,0 +1,72 @@
+---
+- name: Include prerequisite tasks
+  ansible.builtin.include_tasks: setup.yaml
+
+- name: SSLCERTIFICATECHAIN | LINK | --check
+  delegate_to: localhost
+  register: result
+  check_mode: true
+  tags: test
+  netscaler.adc.sslcertificatechain:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    save_config: "{{ save_config }}"
+    state: present
+    certkeyname: "{{ leaf_cert }}"
+
+- name: Assert | SSLCERTIFICATECHAIN | LINK | --check
+  tags: test
+  ansible.builtin.assert:
+    that:
+      - "result.failed==false"
+      - "result.changed==true"
+
+- name: SSLCERTIFICATECHAIN | LINK
+  delegate_to: localhost
+  register: result
+  check_mode: false
+  tags: test
+  netscaler.adc.sslcertificatechain:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    save_config: "{{ save_config }}"
+    state: present
+    certkeyname: "{{ leaf_cert }}"
+
+- name: Assert | SSLCERTIFICATECHAIN | LINK
+  tags: test
+  ansible.builtin.assert:
+    that:
+      - "result.failed==false"
+      - "result.changed==true"
+
+- name: SSLCERTIFICATECHAIN | LINK | idempotent
+  delegate_to: localhost
+  register: result
+  check_mode: false
+  tags: test
+  netscaler.adc.sslcertificatechain:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    save_config: "{{ save_config }}"
+    state: present
+    certkeyname: "{{ leaf_cert }}"
+
+- name: Assert | SSLCERTIFICATECHAIN | LINK | idempotent
+  tags: test
+  ansible.builtin.assert:
+    that:
+      - "result.failed==false"
+      - "result.changed==false"
+
+- name: Include teardown tasks
+  ansible.builtin.include_tasks: teardown.yaml

--- a/tests/integration/targets/sslcertificatechain/tasks/setup.yaml
+++ b/tests/integration/targets/sslcertificatechain/tasks/setup.yaml
@@ -1,0 +1,159 @@
+---
+# Setup: Create a root CA, intermediate CA, and leaf cert for chain linking tests.
+# The leaf is linked to the intermediate via linkcertkeyname, but the intermediate
+# is NOT linked to root. This tests that sslcertificatechain POST completes the chain.
+
+- name: Generate test certificates locally
+  delegate_to: localhost
+  block:
+    - name: Create temp directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: sslchain_test_
+      register: cert_dir
+
+    - name: Generate Root CA key and cert
+      ansible.builtin.command:
+        cmd: >
+          openssl req -x509 -newkey rsa:2048 -nodes
+          -keyout {{ cert_dir.path }}/root.key
+          -out {{ cert_dir.path }}/root.crt
+          -days 365 -subj "/CN=TestChain-RootCA"
+
+    - name: Generate Intermediate key and CSR
+      ansible.builtin.command:
+        cmd: >
+          openssl req -newkey rsa:2048 -nodes
+          -keyout {{ cert_dir.path }}/intermediate.key
+          -out {{ cert_dir.path }}/intermediate.csr
+          -subj "/CN=TestChain-IntermediateCA"
+
+    - name: Sign Intermediate with Root
+      ansible.builtin.command:
+        cmd: >
+          openssl x509 -req
+          -in {{ cert_dir.path }}/intermediate.csr
+          -CA {{ cert_dir.path }}/root.crt
+          -CAkey {{ cert_dir.path }}/root.key
+          -CAcreateserial
+          -out {{ cert_dir.path }}/intermediate.crt
+          -days 365 -extfile /dev/stdin
+        stdin: |
+          basicConstraints=critical,CA:true,pathlen:0
+          keyUsage=critical,keyCertSign,cRLSign
+
+    - name: Generate Leaf key and CSR
+      ansible.builtin.command:
+        cmd: >
+          openssl req -newkey rsa:2048 -nodes
+          -keyout {{ cert_dir.path }}/leaf.key
+          -out {{ cert_dir.path }}/leaf.csr
+          -subj "/CN=TestChain-Leaf"
+
+    - name: Sign Leaf with Intermediate
+      ansible.builtin.command:
+        cmd: >
+          openssl x509 -req
+          -in {{ cert_dir.path }}/leaf.csr
+          -CA {{ cert_dir.path }}/intermediate.crt
+          -CAkey {{ cert_dir.path }}/intermediate.key
+          -CAcreateserial
+          -out {{ cert_dir.path }}/leaf.crt
+          -days 365
+
+- name: Upload Root CA cert file
+  delegate_to: localhost
+  netscaler.adc.systemfile:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    filename: "TestChain-RootCA.crt"
+    filelocation: "/nsconfig/ssl/"
+    fileencoding: "BASE64"
+    filecontent: "{{ lookup('file', cert_dir.path ~ '/root.crt') | b64encode }}"
+
+- name: Upload Intermediate CA cert file
+  delegate_to: localhost
+  netscaler.adc.systemfile:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    filename: "TestChain-IntermediateCA.crt"
+    filelocation: "/nsconfig/ssl/"
+    fileencoding: "BASE64"
+    filecontent: "{{ lookup('file', cert_dir.path ~ '/intermediate.crt') | b64encode }}"
+
+- name: Upload Leaf cert file (leaf + intermediate + root concatenated)
+  delegate_to: localhost
+  netscaler.adc.systemfile:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    filename: "TestChain-Leaf.crt"
+    filelocation: "/nsconfig/ssl/"
+    fileencoding: "BASE64"
+    filecontent: "{{ (lookup('file', cert_dir.path ~ '/leaf.crt') ~ '\n' ~ lookup('file', cert_dir.path ~ '/intermediate.crt') ~ '\n' ~ lookup('file', cert_dir.path ~ '/root.crt')) | b64encode }}"
+
+- name: Upload Leaf key file
+  delegate_to: localhost
+  netscaler.adc.systemfile:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    filename: "TestChain-Leaf.key"
+    filelocation: "/nsconfig/ssl/"
+    fileencoding: "BASE64"
+    filecontent: "{{ lookup('file', cert_dir.path ~ '/leaf.key') | b64encode }}"
+
+- name: Create Root CA certkey
+  delegate_to: localhost
+  netscaler.adc.sslcertkey:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    certkey: "{{ root_cert }}"
+    cert: "TestChain-RootCA.crt"
+    inform: PEM
+
+- name: Create Intermediate CA certkey (NOT linked to root)
+  delegate_to: localhost
+  netscaler.adc.sslcertkey:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    certkey: "{{ intermediate_cert }}"
+    cert: "TestChain-IntermediateCA.crt"
+    inform: PEM
+
+- name: Create Leaf certkey (linked to intermediate only)
+  delegate_to: localhost
+  netscaler.adc.sslcertkey:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: present
+    certkey: "{{ leaf_cert }}"
+    cert: "TestChain-Leaf.crt"
+    key: "TestChain-Leaf.key"
+    inform: PEM
+    linkcertkeyname: "{{ intermediate_cert }}"

--- a/tests/integration/targets/sslcertificatechain/tasks/teardown.yaml
+++ b/tests/integration/targets/sslcertificatechain/tasks/teardown.yaml
@@ -1,0 +1,33 @@
+---
+- name: Delete Leaf certkey
+  delegate_to: localhost
+  netscaler.adc.sslcertkey:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: absent
+    certkey: "{{ leaf_cert }}"
+
+- name: Delete Intermediate certkey
+  delegate_to: localhost
+  netscaler.adc.sslcertkey:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: absent
+    certkey: "{{ intermediate_cert }}"
+
+- name: Delete Root certkey
+  delegate_to: localhost
+  netscaler.adc.sslcertkey:
+    nsip: "{{ nsip }}"
+    nitro_user: "{{ nitro_user }}"
+    nitro_pass: "{{ nitro_pass }}"
+    nitro_protocol: "{{ nitro_protocol }}"
+    validate_certs: "{{ validate_certs }}"
+    state: absent
+    certkey: "{{ root_cert }}"

--- a/tests/integration/targets/sslcertificatechain/vars/main.yaml
+++ b/tests/integration/targets/sslcertificatechain/vars/main.yaml
@@ -1,0 +1,4 @@
+---
+root_cert: "TestChain-RootCA"
+intermediate_cert: "TestChain-IntermediateCA"
+leaf_cert: "TestChain-Leaf"


### PR DESCRIPTION
## Summary

The `sslcertificatechain` module never issues the POST that triggers auto-linking. It does a GET, sees the resource exists (NITRO always returns chain status for any existing certkey), compares only the `certkeyname` field, and returns "no change required".

## Root Cause

The `create_or_update()` flow in `module_executor.py`:
1. GETs `/nitro/v1/config/sslcertificatechain/<certkeyname>` - always returns 200 with chain status
2. Calls `is_resource_identical()` - only compares `certkeyname` (the sole readwrite argument)
3. Finds it identical and skips - the POST that triggers linking is never issued

## Fix

When `chaincomplete == "0"` in the GET response, force a POST to `/nitro/v1/config/sslcertificatechain` to trigger auto-linking. This links certificates by content (AKI/SKI matching) regardless of certkey naming.

Includes:
- Diff output showing `chainlinked`, `chainpossiblelinks`, and `chaincomplete` transitions
- Idempotent: returns `ok` when chain is already complete (`chaincomplete=1`)
- `check_mode` support via existing `client.send()` transport layer (skips non-GET in check mode)
- Integration test covering `--check`, link, and idempotent scenarios

## Testing

Tested against NetScaler NS14.1 Build 66.54.nc with:
- 5-level chain (Root > Int1 > Int2 > Int3 > Leaf): links full chain in one POST
- Multiple leaves from same intermediate: idempotent after first link
- New leaf from different intermediate: correctly links new path
- Certs with mismatched certkey name vs CN: links by content not name
- `--check --diff`: reports changed with diff, no actual POST made

## Example output

```
TASK [Link certificate chain] ************************************
--- before
+++ after
@@ -1,11 +1,11 @@
 {
     "certkeyname": "my-leaf-cert",
-    "chaincomplete": "0",
-    "chainlinked": ["IssuingCA"],
-    "chainpossiblelinks": ["IntermediateCA", "RootCA"]
+    "chaincomplete": "1",
+    "chainlinked": ["IssuingCA", "IntermediateCA", "RootCA"],
+    "chainpossiblelinks": []
 }

changed: [localhost]
```