### PR TITLE
fix(nslimitselector): resolve response key and attribute mismatch breaking idempotency

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -37,6 +37,13 @@ def get_netscaler_version(client):
         return (0.0, 0.0)  # return a dummy version
 
 
+# NITRO-BUG: Some resources return GET response under a different key than the resource name.
+# Map resource_name -> actual response key in the JSON body.
+NITRO_RESPONSE_KEY_ALIASES = {
+    "nslimitselector": "streamselector",
+}
+
+
 @trace
 def get_resource(client, resource_name, resource_id=None, resource_module_params=None):
     if resource_module_params is None:
@@ -112,8 +119,10 @@ def get_resource(client, resource_name, resource_id=None, resource_module_params
         return False, []
     if status_code in HTTP_SUCCESS_CODES:
         # for zero bindings and some resources, the response_body will be {'errorcode': 0, 'message': 'Done', 'severity': 'NONE'}
+        # NITRO-BUG: Some resources return data under a different key (e.g. nslimitselector -> streamselector)
+        response_key = NITRO_RESPONSE_KEY_ALIASES.get(resource_name, resource_name)
         if (
-            resource_name not in response_body
+            response_key not in response_body
             and resource_name not in DYNAMIC_PROTOCOLS
         ):
             if resource_name == "sslcipher":
@@ -129,7 +138,7 @@ def get_resource(client, resource_name, resource_id=None, resource_module_params
                 DYNAMIC_PROTOCOLS_ALIAS[resource_name], {}
             )
         else:
-            return_response = response_body[resource_name]
+            return_response = response_body[response_key]
         # FIXME: NITRO-BUG: for some resources like `policypatset_pattern_binding`, NITRO returns keys with uppercase. eg: `String` for `string`.
         # So, we are converting the keys to lowercase.
         # except for `ping` and `traceroute`, all the othe resources returns a keys with lowercase.

--- a/plugins/module_utils/constants.py
+++ b/plugins/module_utils/constants.py
@@ -33,7 +33,11 @@ NITRO_ATTRIBUTES_ALIASES = {
     "gslbservice": {
         "ip": "ipaddress",
         "ipaddress": "ip",  # For PUT payloads and GET responses
-    }
+    },
+    # NITRO-BUG: nslimitselector GET returns 'name' instead of 'selectorname'
+    "nslimitselector": {
+        "name": "selectorname",
+    },
 }
 
 # https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec


### PR DESCRIPTION
# fix(nslimitselector): resolve response key and attribute mismatch breaking idempotency

## Summary

The `nslimitselector` module isn't idempotent. Every run after the first, `get_existing_resource()` can't find the existing resource, so the module always tries to POST (create) and gets back HTTP 409 "Resource already exists".

## Root Cause

Two NITRO API response inconsistencies that the module doesn't handle:

1. **Response key mismatch**: GET `/nitro/v1/config/nslimitselector/<name>` returns data under the key `streamselector`, not `nslimitselector`. The `get_resource()` function in `common.py` checks `if resource_name not in response_body` and returns `False, []`, so the module thinks the resource doesn't exist.

2. **Attribute name mismatch**: Inside the response payload, the selector name field comes back as `name`, not `selectorname` (the module's primary key). Even if issue 1 is fixed alone, `is_resource_identical()` can't match the primary key.

### NITRO API Evidence (NS14.1 Build 72.61)

**Docs say** the GET response should be:
```json
{ "nslimitselector": [{ "selectorname": "...", "rule": [...] }] }
```

**What actually comes back** from the appliance:
```json
{ "streamselector": [{ "name": "sel_example", "rule": ["CLIENT.IP.SRC"] }] }
```

This looks like `nslimitselector` (under `/ns/`) and `streamselector` (under `/stream/`) are the same underlying resource, and NITRO returns the `stream` representation regardless of which endpoint you hit.

### Duplicate POST error (HTTP 409):
```json
{ "errorcode": 273, "message": "Resource already exists", "severity": "ERROR" }
```

### PUT works fine (idempotent):
```
PUT /nitro/v1/config/nslimitselector -> HTTP 200
{ "errorcode": 0, "message": "Done", "severity": "NONE" }
```

## Fix

Two small changes using existing mechanisms already in the codebase:

### 1. `common.py` - Response key alias

Added `NITRO_RESPONSE_KEY_ALIASES` mapping so `get_resource()` looks for `streamselector` in the response body when handling `nslimitselector`:

```python
NITRO_RESPONSE_KEY_ALIASES = {
    "nslimitselector": "streamselector",
}
```

### 2. `constants.py` - Attribute alias

Added `nslimitselector` to `NITRO_ATTRIBUTES_ALIASES` so the `name` field from the GET response gets aliased to `selectorname` (the module's primary key):

```python
"nslimitselector": {
    "name": "selectorname",
},
```

Both patterns follow existing precedent:
- Response key aliasing mirrors how `sslcipher` and `DYNAMIC_PROTOCOLS` handle similar mismatches in `get_resource()`
- Attribute aliasing uses the same `NITRO_ATTRIBUTES_ALIASES` mechanism as `gslbservice` (`ip` / `ipaddress`)

## Testing

Tested against NetScaler NS14.1 Build 72.61.nc (VPX on AWS):

| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| First run (create) | `changed: true` | `changed: true` |
| Second run (idempotent) | FAILS with 409 | `changed: false` |
| `--check` mode (non-existent) | Reports changed | Reports changed |
| `--check` mode (exists, identical) | Reports changed (wrong) | `changed: false` |
| `--check` mode (exists, different rule) | Reports changed (lucky) | `changed: true` |
| `--diff` output | Always shows create | Shows accurate before/after |
| `state: absent` (delete) | Works | Works |
| Update rule (PUT) | Never reached | `changed: true`, PUT issued |

### Correct idempotent behaviour after fix

```
TASK [Create stream selector (second run)] *****
ok: [localhost] => {"changed": false, ...}

DEBUG: Found alias key `selectorname` for `name`. Adding the alias key to resource_module_params
INFO: Resource `nslimitselector:sel_test` exists and is identical. No change required.
```

### Correct diff output

```diff
--- before
+++ after
@@ -1,6 +1,7 @@
 {
     "rule": [
-        "CLIENT.IP.SRC"
+        "CLIENT.IP.SRC",
+        "HTTP.REQ.URL"
     ],
     "selectorname": "sel_test"
 }
```

## Related

- Similar class of bug to `sslhsmkey` (error code handling), `systemfile` (delete-then-add), and `location` (composite key), all handled with resource-specific logic in `module_executor.py`
- The `nslimitidentifier` module does NOT have this issue. Its GET response correctly returns data under `nslimitidentifier` with the expected field names
